### PR TITLE
GRIDEDIT-165: bug fix, reactivate old unit test

### DIFF
--- a/src/LandBoundaries.cpp
+++ b/src/LandBoundaries.cpp
@@ -43,20 +43,16 @@ namespace meshkernel
         m_mesh(mesh), 
         m_polygons(polygons)
     {
-        m_numNode = 0;
-        m_numAllocatedNodes = 0;
+        m_numNode = int(landBoundary.size());
+
         if (!landBoundary.empty())
         {
             ResizeVectorIfNeededWithMinimumSize(int(landBoundary.size()), m_nodes, m_allocationSize, { doubleMissingValue,doubleMissingValue });
-            m_numAllocatedNodes = int(m_nodes.size());
-
-            m_numNode = 0;
             for (int i = 0; i < landBoundary.size(); i++)
             {
-                m_nodes[m_numNode] = landBoundary[i];
-                m_numNode++;
-            }
+                m_nodes[i] = landBoundary[i];
 
+            }
             m_polygonNodesCache.resize(maximumNumberOfNodesPerFace);
         }
 

--- a/src/LandBoundaries.cpp
+++ b/src/LandBoundaries.cpp
@@ -43,31 +43,24 @@ namespace meshkernel
         m_mesh(mesh), 
         m_polygons(polygons)
     {
-        m_numNode = int(landBoundary.size());
-
         if (!landBoundary.empty())
         {
-            ResizeVectorIfNeededWithMinimumSize(int(landBoundary.size()), m_nodes, m_allocationSize, { doubleMissingValue,doubleMissingValue });
-            for (int i = 0; i < landBoundary.size(); i++)
-            {
-                m_nodes[i] = landBoundary[i];
-
-            }
+            m_nodes.reserve(m_allocationSize);
+            std::copy(landBoundary.begin(), landBoundary.end(), std::back_inserter(m_nodes));
             m_polygonNodesCache.resize(maximumNumberOfNodesPerFace);
         }
-
     }
 
     bool LandBoundaries::Administrate()
     {
-        if (m_numNode<=0)
+        if (m_nodes.empty())
         {
             return true;
         }
 
-        std::vector<int> landBoundaryMask(m_numNode - 1, 0);
+        std::vector<int> landBoundaryMask(m_nodes.size() - 1, 0);
         //mask the landboundary that is inside the selecting polygon
-        for (int n = 0; n < m_numNode - 1; n++)
+        for (int n = 0; n < m_nodes.size() - 1; n++)
         {
             if (m_nodes[n].x != doubleMissingValue && m_nodes[n + 1].x != doubleMissingValue)
             {
@@ -91,7 +84,7 @@ namespace meshkernel
         }
 
         // Mask nodes close enough to land boundary segments 
-        for (int n = 0; n < m_numNode - 1; n++)
+        for (size_t n = 0; n < m_nodes.size() - 1; n++)
         {
             if (landBoundaryMask[n] != 0)
             {
@@ -132,13 +125,12 @@ namespace meshkernel
         }
 
         // In m_segmentIndices: start and ending indexses of segments inside polygon
-        m_segmentIndices.resize(m_numNode, std::vector<int>(2, -1));
-        int begin = 0;
-        int end = m_numNode + 1;
-        while (begin < end)
+        m_segmentIndices.reserve(m_nodes.size());
+        size_t begin = 0;
+        while (begin < m_nodes.size())
         {
-            int found = begin;
-            for (int n = begin; n < end; n++)
+            size_t found = begin;
+            for (int n = begin; n < m_nodes.size(); n++)
             {
                 if (m_nodes[n].x == doubleMissingValue)
                 {
@@ -147,29 +139,26 @@ namespace meshkernel
                 }
             }
 
-            int startInd = begin;
-            int endInd = found - 1;
+            size_t startInd = begin;
+            size_t endInd = found - 1;
             if (endInd > startInd && landBoundaryMask[startInd] != 0)
             {
-                m_segmentIndices[m_numSegments] = { startInd, endInd };
-                m_numSegments++;
+                m_segmentIndices.push_back({ startInd, endInd });
             }
             begin = found + 1;
         }
 
         // Generate two segments for closed land boundaries
-        int numSegmentIndexsesBeforeSplitting = m_numSegments;
-        for (int i = 0; i < numSegmentIndexsesBeforeSplitting; i++)
+        const auto numSegmentIndexsesBeforeSplitting = m_segmentIndices.size();
+        for (size_t i = 0; i < numSegmentIndexsesBeforeSplitting; i++)
         {
-            int startSegmentIndex = m_segmentIndices[i][0];
-            int endSegmentIndex = m_segmentIndices[i][1];
+            const auto startSegmentIndex = m_segmentIndices[i][0];
+            const auto endSegmentIndex = m_segmentIndices[i][1];
             if (endSegmentIndex - startSegmentIndex > 1)
             {
-                int split = int(startSegmentIndex + (endSegmentIndex - startSegmentIndex) / 2);
+                auto split = size_t(startSegmentIndex + (endSegmentIndex - startSegmentIndex) / 2);
                 m_segmentIndices[i][1] = split;
-                m_segmentIndices[m_numSegments][0] = split;
-                m_segmentIndices[m_numSegments][1] = endSegmentIndex;
-                m_numSegments++;
+                m_segmentIndices.push_back({ split , endSegmentIndex });
             }
         }
 
@@ -179,7 +168,7 @@ namespace meshkernel
 
     bool LandBoundaries::FindNearestMeshBoundary(int snapping)
     {
-        if (m_numNode <= 0)
+        if (m_nodes.empty())
         {
             return false;
         }
@@ -203,7 +192,7 @@ namespace meshkernel
         m_nodesMinDistances.resize(m_mesh->GetNumNodes() , doubleMissingValue);
 
         //landBoundarySegment
-        for (int landBoundarySegment = 0; landBoundarySegment < m_numSegments; landBoundarySegment++)
+        for (int landBoundarySegment = 0; landBoundarySegment < m_segmentIndices.size(); landBoundarySegment++)
         {
             int numPaths = 0;
             int numRejectedPaths = 0;
@@ -246,7 +235,7 @@ namespace meshkernel
     /// connect_boundary_paths, build an additional boundary for not assigned nodes  
     bool LandBoundaries::AssignSegmentsToAllMeshNodes(int edgeIndex, bool initialize, std::vector<int>& nodes, int numNodes)
     {
-        if (m_numNode <= 0)
+        if (m_nodes.empty())
         {
             return true;
         }
@@ -342,7 +331,7 @@ namespace meshkernel
                     Point pointOnLandBoundary;
                     int nearestLandBoundaryNodeIndex = -1;
                     double edgeRatio;
-                    bool successful = NearestLandBoundaryNode(m_mesh->m_projection, m_mesh->m_nodes[meshNode], 0, m_numNode, minimumDistance, pointOnLandBoundary, nearestLandBoundaryNodeIndex, edgeRatio);
+                    bool successful = NearestLandBoundaryNode(m_mesh->m_projection, m_mesh->m_nodes[meshNode], 0, m_nodes.size(), minimumDistance, pointOnLandBoundary, nearestLandBoundaryNodeIndex, edgeRatio);
 
                     if (!successful) 
                     {
@@ -350,8 +339,8 @@ namespace meshkernel
                     }
 
                     // find the segment index of the found point
-                    int landboundarySegmentIndex = -1;
-                    for (int s = 0; s < m_numSegments; s++)
+                    size_t landboundarySegmentIndex = std::numeric_limits<size_t>::max();
+                    for (size_t s = 0; s < m_segmentIndices.size(); s++)
                     {
                         if (nearestLandBoundaryNodeIndex >= m_segmentIndices[s][0] && nearestLandBoundaryNodeIndex < m_segmentIndices[s][1])
                         {
@@ -361,7 +350,7 @@ namespace meshkernel
                     }
 
                     //TODO: CHECK
-                    if (landboundarySegmentIndex == -1)
+                    if (landboundarySegmentIndex == std::numeric_limits<size_t>::max())
                         return false;
 
                     if ((nearestLandBoundaryNodeIndex == m_segmentIndices[landboundarySegmentIndex][0] && edgeRatio < 0.0) ||
@@ -370,7 +359,7 @@ namespace meshkernel
                         if (m_addLandboundaries)
                         {
                             AddLandBoundary(nodesLoc, numNodesLoc, lastVisitedNode);
-                            m_meshNodesLandBoundarySegments[meshNode] = m_numSegments - 1; //last added ;and boundary
+                            m_meshNodesLandBoundarySegments[meshNode] = m_segmentIndices.size() - 1; //last added ;and boundary
                         }
                     }
                     else
@@ -390,7 +379,7 @@ namespace meshkernel
     /// add_land, add new land boundary segment that connects two others
     bool LandBoundaries::AddLandBoundary(const std::vector<int>& nodesLoc, int numNodesLoc, int nodeIndex)
     {
-        if (m_numNode <= 0)
+        if (m_nodes.empty())
         {
             return true;
         }
@@ -400,15 +389,15 @@ namespace meshkernel
         int startSegmentIndex = m_meshNodesLandBoundarySegments[nodesLoc[0]];
         int endSegmentIndex = m_meshNodesLandBoundarySegments[nodesLoc[numNodesLoc]];
 
-        if (startSegmentIndex < 0 || startSegmentIndex >= m_numSegments ||
-            endSegmentIndex < 0 || endSegmentIndex >= m_numSegments)
+        if (startSegmentIndex < 0 || startSegmentIndex >= m_segmentIndices.size() ||
+            endSegmentIndex < 0 || endSegmentIndex >= m_segmentIndices.size())
         {
             return false;
         }
 
         // find start/end
-        int startNode = m_segmentIndices[startSegmentIndex][0];
-        int endNode = m_segmentIndices[startSegmentIndex][1];
+        auto startNode = m_segmentIndices[startSegmentIndex][0];
+        auto endNode = m_segmentIndices[startSegmentIndex][1];
 
         Point newNodeLeft;
         if (ComputeSquaredDistance(m_mesh->m_nodes[nodeIndex], m_nodes[startNode], m_mesh->m_projection) <= ComputeSquaredDistance(m_mesh->m_nodes[nodeIndex], m_nodes[endNode], m_mesh->m_projection))
@@ -441,18 +430,13 @@ namespace meshkernel
         }
 
         // Update  nodes
-        int minSize = m_numNode + 3;
-        ResizeVectorIfNeededWithMinimumSize(minSize, m_nodes, m_allocationSize, { doubleMissingValue,doubleMissingValue });
-        m_numNode += 3;
-        m_nodes[m_numNode - 2] = newNodeLeft;
-        m_nodes[m_numNode - 1] = newNodeRight;
+        m_nodes.push_back({ doubleMissingValue, doubleMissingValue });
+        m_nodes.push_back(newNodeLeft);
+        m_nodes.push_back(newNodeRight);
+        m_nodes.push_back({ doubleMissingValue, doubleMissingValue });
 
         // Update segment indexses
-        minSize = m_numSegments + 1;
-        ResizeVectorIfNeededWithMinimumSize(minSize, m_segmentIndices, m_allocationSize, { -1, -1 });
-        m_segmentIndices[m_numSegments][0] = m_numNode - 2;
-        m_segmentIndices[m_numSegments][1] = m_numNode - 1;
-        m_numSegments++;
+        m_segmentIndices.push_back({ m_nodes.size() - 3,  m_nodes.size() - 2 });
 
         return successful;
     }
@@ -464,15 +448,15 @@ namespace meshkernel
                                    int& numNodesInPath,
                                    int& numRejectedNodesInPath )
     {
-        if (m_numNode <= 0)
+        if (m_nodes.empty())
         {
             return true;
         }
 
-        int startLandBoundaryIndex = m_segmentIndices[landBoundarySegment][0];
-        int endLandBoundaryIndex = m_segmentIndices[landBoundarySegment][1];
+        auto startLandBoundaryIndex = m_segmentIndices[landBoundarySegment][0];
+        auto endLandBoundaryIndex = m_segmentIndices[landBoundarySegment][1];
 
-        if (startLandBoundaryIndex < 0 || startLandBoundaryIndex >= m_numNode || startLandBoundaryIndex >= endLandBoundaryIndex)
+        if (startLandBoundaryIndex < 0 || startLandBoundaryIndex >= m_nodes.size() || startLandBoundaryIndex >= endLandBoundaryIndex)
             return false;
 
         // fractional location of the projected outer nodes(min and max) on the land boundary segment
@@ -537,8 +521,8 @@ namespace meshkernel
             {
                 // Multiple boundary segments: take the nearest
                 int previousLandBoundarySegment = m_meshNodesLandBoundarySegments[currentNode];
-                int previousStartMeshNode = m_segmentIndices[previousLandBoundarySegment][0];
-                int previousEndMeshNode = m_segmentIndices[previousLandBoundarySegment][1];
+                auto previousStartMeshNode = m_segmentIndices[previousLandBoundarySegment][0];
+                auto previousEndMeshNode = m_segmentIndices[previousLandBoundarySegment][1];
                 double previousMinDistance;
 
                 successful = NearestLandBoundaryNode(m_mesh->m_projection, m_mesh->m_nodes[currentNode], previousStartMeshNode, previousEndMeshNode,
@@ -563,7 +547,7 @@ namespace meshkernel
             {
                 if (m_nodesMinDistances[currentNode] == doubleMissingValue)
                 {
-                    successful = NearestLandBoundaryNode(m_mesh->m_projection, m_mesh->m_nodes[currentNode], 0, m_numNode,
+                    successful = NearestLandBoundaryNode(m_mesh->m_projection, m_mesh->m_nodes[currentNode], 0, m_nodes.size(),
                         minDinstanceFromLandBoundary, nodeOnLandBoundary, currentNodeLandBoundaryNodeIndex, currentNodeEdgeRatio);
                     if (!successful)
                         return false;
@@ -653,7 +637,7 @@ namespace meshkernel
                                       double& leftEdgeRatio,
                                       double& rightEdgeRatio )
     {
-        if (m_numNode <= 0)
+        if (m_nodes.empty())
         {
             return true;
         }
@@ -775,7 +759,7 @@ namespace meshkernel
         double& leftEdgeRatio,
         double& rightEdgeRatio)
     {
-        if (m_numNode <= 0)
+        if (m_nodes.empty())
         {
             return true;
         }
@@ -929,7 +913,7 @@ namespace meshkernel
         double& rightEdgeRatio,
         int& landBoundaryNode)
     {
-        if (m_numNode <= 0)
+        if (m_nodes.empty())
         {
             return true;
         }
@@ -1054,7 +1038,7 @@ namespace meshkernel
                                                 int& startMeshNode,
                                                 int& endMeshNode)
     {
-        if (m_numNode <= 0)
+        if (m_nodes.empty())
         {
             return true;
         }
@@ -1169,7 +1153,7 @@ namespace meshkernel
                                        bool meshBoundOnly, 
                                        std::vector<int>& connectedNodes)
     {
-        if (m_numNode <= 0)
+        if (m_nodes.empty())
         {
             return true;
         }
@@ -1311,7 +1295,7 @@ namespace meshkernel
                                                   int& nearestLandBoundaryNodeIndex,
                                                   double& edgeRatio )
     {
-        if (m_numNode <= 0)
+        if (m_nodes.empty())
         {
             return true;
         }
@@ -1347,7 +1331,7 @@ namespace meshkernel
     /// TODO: it could be moved to generic operations
     bool LandBoundaries::IsFaceCrossedByLandBoundaries(int face, int startLandBoundaryIndex, int endLandBoundaryIndex)
     {
-        if (m_numNode <= 0)
+        if (m_nodes.empty())
         {
             return true;
         }
@@ -1385,7 +1369,7 @@ namespace meshkernel
     bool LandBoundaries::SnapMeshToLandBoundaries()
     {
 
-        if (m_numNode <= 0)
+        if (m_nodes.empty())
         {
             return true;
         }

--- a/src/LandBoundaries.cpp
+++ b/src/LandBoundaries.cpp
@@ -43,18 +43,21 @@ namespace meshkernel
         m_mesh(mesh), 
         m_polygons(polygons)
     {
-        ResizeVectorIfNeededWithMinimumSize(m_numAllocatedNodes, m_nodes, m_allocationSize, { doubleMissingValue,doubleMissingValue });
-        m_numAllocatedNodes = int(m_nodes.size());
         m_numNode = 0;
-        m_polygonNodesCache.resize(maximumNumberOfNodesPerFace);
-
-        ResizeVectorIfNeededWithMinimumSize(m_numNode + int(landBoundary.size()), m_nodes, m_allocationSize, { doubleMissingValue,doubleMissingValue });
-        m_numAllocatedNodes = int(m_nodes.size());
-
-        for (int i = 0; i < landBoundary.size(); i++)
+        m_numAllocatedNodes = 0;
+        if (!landBoundary.empty())
         {
-            m_nodes[m_numNode] = landBoundary[i];
-            m_numNode++;
+            ResizeVectorIfNeededWithMinimumSize(int(landBoundary.size()), m_nodes, m_allocationSize, { doubleMissingValue,doubleMissingValue });
+            m_numAllocatedNodes = int(m_nodes.size());
+
+            m_numNode = 0;
+            for (int i = 0; i < landBoundary.size(); i++)
+            {
+                m_nodes[m_numNode] = landBoundary[i];
+                m_numNode++;
+            }
+
+            m_polygonNodesCache.resize(maximumNumberOfNodesPerFace);
         }
 
     }

--- a/src/LandBoundaries.hpp
+++ b/src/LandBoundaries.hpp
@@ -268,7 +268,6 @@ namespace meshkernel
         std::shared_ptr<Polygons> m_polygons;             // A pointer to polygons
 
         std::vector<Point> m_nodes;                       // XLAN, YLAN, ZLAN
-        int m_numAllocatedNodes;                          // MAXLAN
         int m_numNode;                                    // actual MXLAN
 
         int m_numSegments = 0;                            // Nlanseg, number of land boundary segments 

--- a/src/LandBoundaries.hpp
+++ b/src/LandBoundaries.hpp
@@ -266,12 +266,9 @@ namespace meshkernel
 
         std::shared_ptr<Mesh>     m_mesh;                 // A pointer to mesh 
         std::shared_ptr<Polygons> m_polygons;             // A pointer to polygons
+        std::vector<Point>        m_nodes;                // XLAN, YLAN, ZLAN
 
-        std::vector<Point> m_nodes;                       // XLAN, YLAN, ZLAN
-        int m_numNode;                                    // actual MXLAN
-
-        int m_numSegments = 0;                            // Nlanseg, number of land boundary segments 
-        std::vector<std::vector<int>> m_segmentIndices;   // lanseg_startend
+        std::vector<std::vector<size_t>> m_segmentIndices;   // lanseg_startend
         std::vector<std::vector<double>> m_nodesLand;     // !node to land boundary segment mapping
 
         std::vector<int> m_nodeMask;                      // nodemask, masking the net nodes
@@ -286,7 +283,7 @@ namespace meshkernel
         // caches
         std::vector<Point> m_polygonNodesCache;          // array of points (e.g. points of a face)
         std::vector<double> m_nodesMinDistances;
-        const int m_allocationSize = 10000;               // allocation size for allocateVector
+        const size_t m_allocationSize = 10000;               // allocation size for allocateVector
 
         // Parameters
         const double m_closeToLandBoundaryFactor = 5.0;   // close - to - landboundary tolerance, measured in number of meshwidths

--- a/src/tests/LandBoundaryTest.cpp
+++ b/src/tests/LandBoundaryTest.cpp
@@ -17,7 +17,8 @@ TEST(LandBoundaries, OneLandBoundary)
         { 222.621918, 382.651917 },
         { 316.206177, 461.190796 },
         { 350.811279, 465.102692 },
-        { 510.295715, 438.923065 }
+        { 510.295715, 438.923065 },
+        { meshkernel::doubleMissingValue, meshkernel::doubleMissingValue }
     };
 
     auto polygons =std::make_shared<meshkernel::Polygons>();
@@ -55,7 +56,8 @@ TEST(LandBoundaries, TwoLandBoundaries)
         { 250.253036, 235.233246 },
         { 423.158325, 200.652054 },
         { 559.938782, 312.732147 },
-        { 518.873718, 421.415894 }
+        { 518.873718, 421.415894 },
+        { meshkernel::doubleMissingValue, meshkernel::doubleMissingValue }
     };
 
     auto polygons =std::make_shared<meshkernel::Polygons>();
@@ -88,7 +90,8 @@ TEST(LandBoundaries, OneCrossingLandBoundary)
         { 248.801422, 375.129028 },
         { 337.571045, 459.686218 },
         { 516.313965, 419.062683 },
-        { 528.651428, 292.377380 }
+        { 528.651428, 292.377380 },
+        { meshkernel::doubleMissingValue, meshkernel::doubleMissingValue }
     };
 
     auto polygons =std::make_shared<meshkernel::Polygons>();
@@ -126,6 +129,7 @@ TEST(LandBoundaries, TwoCrossingLandBoundary)
         { 351.112183, 237.309906 },
         { 443.191895, 262.285858 },
         { 553.627319, 327.283539 },
+        { meshkernel::doubleMissingValue, meshkernel::doubleMissingValue }
     };
 
     auto polygons =std::make_shared<meshkernel::Polygons>();

--- a/src/tests/OrthogonalizationTest.cpp
+++ b/src/tests/OrthogonalizationTest.cpp
@@ -410,6 +410,7 @@ TEST(OrthogonalizationAndSmoothing, OrthogonalizeAndSnapToLandBoundaries)
         { 351.112183, 237.309906 },
         { 443.191895, 262.285858 },
         { 553.627319, 327.283539 },
+        { meshkernel::doubleMissingValue, meshkernel::doubleMissingValue }
     };
 
     

--- a/src/tests/OrthogonalizationTest.cpp
+++ b/src/tests/OrthogonalizationTest.cpp
@@ -289,8 +289,6 @@ TEST(OrthogonalizationAndSmoothing, OrthogonalizationMediumTriangularGridWithPol
 
 }
 
-/*
-* temporarly disabled, failure maybe due to openmp threading
 TEST(OrthogonalizationAndSmoothing, OrthogonalizationMediumTriangularGrid)
 {
     // now build node-edge mapping
@@ -310,10 +308,8 @@ TEST(OrthogonalizationAndSmoothing, OrthogonalizationMediumTriangularGrid)
     auto orthogonalizer = std::make_shared<meshkernel::Orthogonalizer>(mesh);
     auto smoother = std::make_shared<meshkernel::Smoother>(mesh);
     auto polygon = std::make_shared<meshkernel::Polygons>();
-    auto landBoundaries = std::make_shared<meshkernel::LandBoundaries>();
-
     std::vector<meshkernel::Point> landBoundary;
-    landBoundaries->Set(landBoundary, mesh, polygon);
+    auto landBoundaries = std::make_shared<meshkernel::LandBoundaries>(landBoundary, mesh, polygon);
 
     meshkernel::OrthogonalizationAndSmoothing orthogonalization( mesh, 
                                                                  smoother, 
@@ -358,7 +354,6 @@ TEST(OrthogonalizationAndSmoothing, OrthogonalizationMediumTriangularGrid)
     ASSERT_NEAR(1631.412199601948, mesh->m_nodes[9].y, tolerance);
 
 }
-*/
 
 TEST(OrthogonalizationAndSmoothing, OrthogonalizationFourQuads)
 {


### PR DESCRIPTION
LandBoundaries is not the best example of clean implementation. An initialized variable causes a wrong allocation and inconsistent unit test run times. 

LandBoundaries needs to be refactored in a separate issue
