### PR TITLE
GRIDEDIT-166: Fix `mkernel_deallocate_state`

### DIFF
--- a/src/MeshKernel.cpp
+++ b/src/MeshKernel.cpp
@@ -175,12 +175,12 @@ namespace meshkernelapi
 
     MKERNEL_API int mkernel_deallocate_state(int meshKernelId)
     {
-        if (meshKernelId >= meshInstances.size())
+        if (meshKernelId < 0 && meshKernelId >= meshInstances.size())
         {
             return -1;
         }
 
-        meshInstances.pop_back();
+        meshInstances.erase(meshInstances.begin() + meshKernelId);
         return 0;
     }
 


### PR DESCRIPTION
I wonder if `meshInstances` should be a linked list instead of a vector.
`erase` is quite expensive if not done at the end of the vector.

Please see https://issuetracker.deltares.nl/browse/GRIDEDIT-166